### PR TITLE
Add context summarizer, roadmap CLI, repo-local init, and help topics; update config and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ dist/
 vectra-guard.yaml
 vectra-guard.toml
 
+# Repo-local cache data
+.vectra-guard/cache/
+
 # Development/internal documentation
 roadmap.md
 *_ACTION_PLAN.md

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -11,6 +11,7 @@ After following this guide:
 - ✅ Risky commands will be caught automatically
 - ✅ Full audit trail of everything executed
 - ✅ Works transparently - no workflow changes needed
+- ✅ Optional agent helpers: context summaries + roadmap planning
 
 ---
 
@@ -55,6 +56,45 @@ echo $VECTRAGUARD_SESSION_ID
 ```
 
 **Expected output**: `session-1234567890...`
+
+---
+
+## 🧭 Optional: Supercharge Agent Workflows
+
+### 1) Repo-local config + cache
+
+```bash
+# Create repo-scoped config and cache directory
+vg init --local
+```
+
+This writes `.vectra-guard/config.yaml` and creates `.vectra-guard/cache` (ignored in git). Use it for per-repo settings without polluting global config.
+
+### 2) Context summaries (quick code mapping)
+
+```bash
+# Summarize key functions in a Go file
+vg context summarize advanced cmd/root.go --max 3
+
+# Summarize docs quickly
+vg context summarize docs README.md --max 3
+```
+
+### 3) Roadmap planning
+
+```bash
+# Capture a plan item and add logs as you work
+vg roadmap add --title "Investigate sandbox cache" --summary "Check hit rate on CI"
+vg roadmap log rm-123456789 --note "Checked cache stats in metrics"
+```
+
+### 4) Built-in help
+
+```bash
+vg help
+vg help context
+vg help roadmap
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 
 Vectra Guard is a comprehensive security tool that protects systems from risky shell commands and AI agent activities. It validates scripts, monitors command execution, detects database operations, tracks agent sessions, and enforces security policies with real-time protection including production environment warnings.
 
+**Agentic development boost:** Vectra Guard now includes **context summarization** and **roadmap planning** so agents can quickly map a repo, capture intent, and move faster without leaving your machine.
+
+**Why it helps agent workflows**
+- **Safety by default**: risky commands are analyzed before they run.
+- **Sandbox + cache**: isolate unknown code, reuse cached dependencies.
+- **Context summaries**: quickly surface key functions or doc sentences.
+- **Roadmap planning**: capture intent, status, and notes per repo.
+- **Repo-local config**: keep workspace settings and cache local (safe to commit config, ignore cache).
+
 ---
 
 ## 🎯 Why Vectra Guard?
@@ -167,6 +176,9 @@ Use Vectra Guard commands directly:
 ```bash
 # Initialize configuration
 vectra-guard init
+
+# Initialize repo-local config + cache
+vectra-guard init --local
 
 # Validate a script (use 'vg' as shorthand if you have universal protection)
 vectra-guard validate your-script.sh
@@ -437,6 +449,9 @@ sandbox:
 # Initialize configuration
 vectra-guard init
 
+# Initialize repo-local config + cache
+vectra-guard init --local
+
 # Validate a shell script
 vectra-guard validate deploy.sh
 
@@ -489,6 +504,49 @@ vg trust remove "npm install express"
 
 # Clean expired entries
 vg trust clean
+```
+
+### Context Summaries
+
+```bash
+# Summarize code with lightweight heuristics
+vg context summarize code cmd/root.go --max 5
+
+# Summarize docs/text with extractive sentences
+vg context summarize docs README.md --max 3
+
+# Advanced Go mode: AST-based function summaries with call graph signals
+vg context summarize advanced cmd/root.go --max 3
+```
+
+### Help Topics
+
+```bash
+# Show available help topics
+vg help
+
+# Get detailed usage for roadmap and context
+vg help roadmap
+vg help context
+```
+
+### Roadmap Planning (NEW!)
+
+```bash
+# Add a roadmap item for agent + human planning
+vg roadmap add --title "Improve cache heuristics" --summary "Tune cache hit scoring" --tags "agent,performance"
+
+# List recent roadmap items
+vg roadmap list
+
+# Show a roadmap item with logs
+vg roadmap show rm-123456789
+
+# Update status
+vg roadmap status rm-123456789 in-progress
+
+# Attach a log entry (optionally link a session)
+vg roadmap log rm-123456789 --note "Investigated cache hit rate" --session $VECTRAGUARD_SESSION_ID
 ```
 
 ### Sandbox Metrics (NEW!)

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/vectra-guard/vectra-guard/internal/logging"
+	"github.com/vectra-guard/vectra-guard/internal/summarizer"
+)
+
+func runContextSummarize(ctx context.Context, mode, path string, maxItems int) error {
+	logger := logging.FromContext(ctx)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read file: %w", err)
+	}
+
+	mode = strings.ToLower(mode)
+	var summary []string
+	switch mode {
+	case "code":
+		summary = summarizer.SummarizeCode(string(content), maxItems)
+	case "advanced":
+		summary = summarizer.SummarizeCodeAdvanced(string(content), maxItems)
+	case "docs", "doc", "text":
+		summary = summarizer.SummarizeText(string(content), maxItems)
+	default:
+		return fmt.Errorf("unknown summarize mode: %s", mode)
+	}
+
+	if len(summary) == 0 {
+		logger.Info("summary produced no highlights", map[string]any{"path": path, "mode": mode})
+		return nil
+	}
+
+	for _, line := range summary {
+		logger.Info("summary line", map[string]any{"path": path, "mode": mode, "summary": line})
+	}
+	return nil
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "strings"
+
+func splitCSV(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		result = append(result, trimmed)
+	}
+	return result
+}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func runHelp(ctx context.Context, topic string) error {
+	topic = strings.ToLower(strings.TrimSpace(topic))
+	switch topic {
+	case "", "all":
+		return printHelp(`Vectra Guard help:
+
+  vg help [topic]
+
+Topics:
+  context   Summarize code/docs for navigation
+  roadmap   Track repo-specific planning items
+  init      Initialize config (including repo-local)
+`)
+	case "context":
+		return printHelp(`Context summaries:
+
+  vg context summarize code <file> --max 5
+  vg context summarize docs <file> --max 3
+  vg context summarize advanced <file> --max 3
+
+Advanced mode parses Go files and surfaces high-impact functions with call-graph signals.
+`)
+	case "roadmap":
+		return printHelp(`Roadmap planning:
+
+  vg roadmap add --title "Title" --summary "Details" --tags "agent,plan"
+  vg roadmap list [--status planned]
+  vg roadmap show <id>
+  vg roadmap status <id> <status>
+  vg roadmap log <id> --note "Update" --session <session-id>
+
+Roadmaps are stored per workspace under ~/.vectra-guard/roadmaps.
+`)
+	case "init":
+		return printHelp(`Initialization:
+
+  vg init            # writes vectra-guard.yaml in repo root
+  vg init --toml     # writes vectra-guard.toml
+  vg init --local    # writes .vectra-guard/config.yaml and sets cache_dir
+
+Local init creates a repo-scoped cache directory at .vectra-guard/cache.
+`)
+	default:
+		return printHelp(fmt.Sprintf("Unknown help topic: %s\n", topic))
+	}
+}
+
+func printHelp(message string) error {
+	_, err := fmt.Fprint(os.Stdout, message)
+	return err
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vectra-guard/vectra-guard/internal/logging"
 )
 
-func runInit(ctx context.Context, force bool, tomlFormat bool) error {
+func runInit(ctx context.Context, force bool, tomlFormat bool, local bool) error {
 	logger := logging.FromContext(ctx)
 	cfg := config.DefaultConfig()
 	cfg.Policies.Allowlist = []string{"echo \"safe\"", "touch /tmp/ok"}
@@ -24,6 +24,21 @@ func runInit(ctx context.Context, force bool, tomlFormat bool) error {
 	target := filepath.Join(workdir, "vectra-guard.yaml")
 	if tomlFormat {
 		target = filepath.Join(workdir, "vectra-guard.toml")
+	}
+	if local {
+		target = filepath.Join(workdir, ".vectra-guard", "config.yaml")
+		if tomlFormat {
+			target = filepath.Join(workdir, ".vectra-guard", "config.toml")
+		}
+		cacheDir := filepath.Join(workdir, ".vectra-guard", "cache")
+		cfg.Sandbox.CacheDir = cacheDir
+		cfg.Sandbox.WorkspaceDir = workdir
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create local config directory: %w", err)
+		}
+		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+			return fmt.Errorf("create local cache directory: %w", err)
+		}
 	}
 
 	if _, err := os.Stat(target); err == nil && !force {
@@ -55,6 +70,9 @@ func encodeTOML(cfg config.Config) (string, error) {
 	builder.WriteString("[policies]\n")
 	builder.WriteString(formatArray("allowlist", cfg.Policies.Allowlist))
 	builder.WriteString(formatArray("denylist", cfg.Policies.Denylist))
+	builder.WriteString("\n[sandbox]\n")
+	builder.WriteString(fmt.Sprintf("cache_dir = \"%s\"\n", cfg.Sandbox.CacheDir))
+	builder.WriteString(fmt.Sprintf("workspace_dir = \"%s\"\n", cfg.Sandbox.WorkspaceDir))
 	builder.WriteString("\n[env_protection]\n")
 	builder.WriteString(fmt.Sprintf("enabled = %t\n", cfg.EnvProtection.Enabled))
 	builder.WriteString(fmt.Sprintf("masking_mode = \"%s\"  # Options: full, partial, hash, fake\n", cfg.EnvProtection.MaskingMode))
@@ -77,6 +95,9 @@ func encodeYAML(cfg config.Config) (string, error) {
 	for _, item := range cfg.Policies.Denylist {
 		builder.WriteString(fmt.Sprintf("    - %s\n", item))
 	}
+	builder.WriteString("sandbox:\n")
+	builder.WriteString(fmt.Sprintf("  cache_dir: %s\n", cfg.Sandbox.CacheDir))
+	builder.WriteString(fmt.Sprintf("  workspace_dir: %s\n", cfg.Sandbox.WorkspaceDir))
 	builder.WriteString("env_protection:\n")
 	builder.WriteString(fmt.Sprintf("  enabled: %t\n", cfg.EnvProtection.Enabled))
 	builder.WriteString(fmt.Sprintf("  masking_mode: %s  # Options: full, partial, hash, fake\n", cfg.EnvProtection.MaskingMode))

--- a/cmd/roadmap.go
+++ b/cmd/roadmap.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/vectra-guard/vectra-guard/internal/config"
+	"github.com/vectra-guard/vectra-guard/internal/logging"
+	"github.com/vectra-guard/vectra-guard/internal/roadmap"
+)
+
+func runRoadmapAdd(ctx context.Context, title, summary, status string, tags []string) error {
+	manager, rm, err := loadRoadmap(ctx)
+	if err != nil {
+		return err
+	}
+	if title == "" {
+		return fmt.Errorf("title is required")
+	}
+	item := roadmap.Item{
+		Title:   title,
+		Summary: summary,
+		Status:  status,
+		Tags:    normalizeTags(tags),
+	}
+	if item.Status == "" {
+		item.Status = "planned"
+	}
+	return manager.AddItem(rm, item)
+}
+
+func runRoadmapList(ctx context.Context, status string) error {
+	manager, rm, err := loadRoadmap(ctx)
+	if err != nil {
+		return err
+	}
+	logger := logging.FromContext(ctx)
+	items := manager.ListItems(rm)
+	if status != "" {
+		status = strings.ToLower(status)
+	}
+	for _, item := range items {
+		if status != "" && strings.ToLower(item.Status) != status {
+			continue
+		}
+		logger.Info("roadmap item", map[string]any{
+			"id":      item.ID,
+			"title":   item.Title,
+			"status":  item.Status,
+			"summary": item.Summary,
+			"tags":    strings.Join(item.Tags, ","),
+			"updated": item.UpdatedAt.Format("2006-01-02"),
+		})
+	}
+	return nil
+}
+
+func runRoadmapShow(ctx context.Context, itemID string) error {
+	manager, rm, err := loadRoadmap(ctx)
+	if err != nil {
+		return err
+	}
+	item := manager.GetItem(rm, itemID)
+	if item == nil {
+		return fmt.Errorf("item not found: %s", itemID)
+	}
+	logger := logging.FromContext(ctx)
+	logger.Info("roadmap item", map[string]any{
+		"id":      item.ID,
+		"title":   item.Title,
+		"status":  item.Status,
+		"summary": item.Summary,
+		"tags":    strings.Join(item.Tags, ","),
+		"created": item.CreatedAt.Format(timeLayout),
+		"updated": item.UpdatedAt.Format(timeLayout),
+	})
+	for _, logEntry := range item.Logs {
+		logger.Info("roadmap log", map[string]any{
+			"item_id": item.ID,
+			"time":    logEntry.Timestamp.Format(timeLayout),
+			"note":    logEntry.Note,
+			"session": logEntry.SessionID,
+			"source":  logEntry.Source,
+		})
+	}
+	return nil
+}
+
+func runRoadmapStatus(ctx context.Context, itemID, status string) error {
+	manager, rm, err := loadRoadmap(ctx)
+	if err != nil {
+		return err
+	}
+	if status == "" {
+		return fmt.Errorf("status is required")
+	}
+	return manager.UpdateStatus(rm, itemID, status)
+}
+
+func runRoadmapLog(ctx context.Context, itemID, note, sessionID, source string) error {
+	manager, rm, err := loadRoadmap(ctx)
+	if err != nil {
+		return err
+	}
+	if note == "" {
+		return fmt.Errorf("note is required")
+	}
+	entry := roadmap.LogEntry{
+		Note:      note,
+		SessionID: sessionID,
+		Source:    source,
+	}
+	if entry.Source == "" {
+		entry.Source = "manual"
+	}
+	return manager.AddLog(rm, itemID, entry)
+}
+
+func loadRoadmap(ctx context.Context) (*roadmap.Manager, *roadmap.Roadmap, error) {
+	logger := logging.FromContext(ctx)
+	cfg := config.FromContext(ctx)
+	workspace := cfg.Sandbox.WorkspaceDir
+	if workspace == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve workspace: %w", err)
+		}
+		workspace = cwd
+	}
+	manager, err := roadmap.NewManager(workspace, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	rm, err := manager.Load()
+	if err != nil {
+		return nil, nil, err
+	}
+	return manager, rm, nil
+}
+
+func normalizeTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		clean := strings.TrimSpace(strings.ToLower(tag))
+		if clean == "" {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		result = append(result, clean)
+	}
+	return result
+}
+
+const timeLayout = "2006-01-02 15:04:05"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,12 +12,12 @@ import (
 
 // Config represents the merged configuration for vectra-guard.
 type Config struct {
-	Logging              LoggingConfig            `yaml:"logging" toml:"logging" json:"logging"`
-	Policies             PolicyConfig             `yaml:"policies" toml:"policies" json:"policies"`
-	EnvProtection        EnvProtectionConfig      `yaml:"env_protection" toml:"env_protection" json:"env_protection"`
-	GuardLevel           GuardLevelConfig         `yaml:"guard_level" toml:"guard_level" json:"guard_level"`
+	Logging              LoggingConfig              `yaml:"logging" toml:"logging" json:"logging"`
+	Policies             PolicyConfig               `yaml:"policies" toml:"policies" json:"policies"`
+	EnvProtection        EnvProtectionConfig        `yaml:"env_protection" toml:"env_protection" json:"env_protection"`
+	GuardLevel           GuardLevelConfig           `yaml:"guard_level" toml:"guard_level" json:"guard_level"`
 	ProductionIndicators ProductionIndicatorsConfig `yaml:"production_indicators" toml:"production_indicators" json:"production_indicators"`
-	Sandbox              SandboxConfig            `yaml:"sandbox" toml:"sandbox" json:"sandbox"`
+	Sandbox              SandboxConfig              `yaml:"sandbox" toml:"sandbox" json:"sandbox"`
 }
 
 // LoggingConfig controls output formatting.
@@ -47,14 +47,14 @@ type GuardLevelConfig struct {
 
 // PolicyConfig captures simple allow/deny rules applied during analysis.
 type PolicyConfig struct {
-	Allowlist           []string `yaml:"allowlist" toml:"allowlist" json:"allowlist"`
-	Denylist            []string `yaml:"denylist" toml:"denylist" json:"denylist"`
+	Allowlist            []string `yaml:"allowlist" toml:"allowlist" json:"allowlist"`
+	Denylist             []string `yaml:"denylist" toml:"denylist" json:"denylist"`
 	ProtectedDirectories []string `yaml:"protected_directories" toml:"protected_directories" json:"protected_directories"`
-	MonitorGitOps       bool     `yaml:"monitor_git_ops" toml:"monitor_git_ops" json:"monitor_git_ops"`
-	BlockForceGit       bool     `yaml:"block_force_git" toml:"block_force_git" json:"block_force_git"`
-	DetectProdEnv       bool     `yaml:"detect_prod_env" toml:"detect_prod_env" json:"detect_prod_env"`
-	ProdEnvPatterns     []string `yaml:"prod_env_patterns" toml:"prod_env_patterns" json:"prod_env_patterns"`
-	OnlyDestructiveSQL  bool     `yaml:"only_destructive_sql" toml:"only_destructive_sql" json:"only_destructive_sql"`
+	MonitorGitOps        bool     `yaml:"monitor_git_ops" toml:"monitor_git_ops" json:"monitor_git_ops"`
+	BlockForceGit        bool     `yaml:"block_force_git" toml:"block_force_git" json:"block_force_git"`
+	DetectProdEnv        bool     `yaml:"detect_prod_env" toml:"detect_prod_env" json:"detect_prod_env"`
+	ProdEnvPatterns      []string `yaml:"prod_env_patterns" toml:"prod_env_patterns" json:"prod_env_patterns"`
+	OnlyDestructiveSQL   bool     `yaml:"only_destructive_sql" toml:"only_destructive_sql" json:"only_destructive_sql"`
 }
 
 // EnvProtectionConfig controls environment variable protection and masking.
@@ -78,7 +78,7 @@ type ProductionIndicatorsConfig struct {
 type SandboxMode string
 
 const (
-	SandboxModeAuto  SandboxMode = "auto"  // Auto-detect based on risk
+	SandboxModeAuto   SandboxMode = "auto"   // Auto-detect based on risk
 	SandboxModeAlways SandboxMode = "always" // Always sandbox
 	SandboxModeRisky  SandboxMode = "risky"  // Only high/critical risk
 	SandboxModeNever  SandboxMode = "never"  // Never sandbox
@@ -108,48 +108,48 @@ const (
 // SandboxConfig controls sandbox execution behavior
 type SandboxConfig struct {
 	// Core settings
-	Enabled        bool                 `yaml:"enabled" toml:"enabled" json:"enabled"`
-	Mode           SandboxMode          `yaml:"mode" toml:"mode" json:"mode"`
-	SecurityLevel  SandboxSecurityLevel `yaml:"security_level" toml:"security_level" json:"security_level"`
-	
+	Enabled       bool                 `yaml:"enabled" toml:"enabled" json:"enabled"`
+	Mode          SandboxMode          `yaml:"mode" toml:"mode" json:"mode"`
+	SecurityLevel SandboxSecurityLevel `yaml:"security_level" toml:"security_level" json:"security_level"`
+
 	// Runtime configuration
-	Runtime        string `yaml:"runtime" toml:"runtime" json:"runtime"` // auto, bubblewrap, namespace, docker, podman
-	Image          string `yaml:"image" toml:"image" json:"image"`       // Docker/Podman image
-	Timeout        int    `yaml:"timeout" toml:"timeout" json:"timeout"` // seconds
-	
+	Runtime string `yaml:"runtime" toml:"runtime" json:"runtime"` // auto, bubblewrap, namespace, docker, podman
+	Image   string `yaml:"image" toml:"image" json:"image"`       // Docker/Podman image
+	Timeout int    `yaml:"timeout" toml:"timeout" json:"timeout"` // seconds
+
 	// Environment detection
-	AutoDetectEnv  bool   `yaml:"auto_detect_env" toml:"auto_detect_env" json:"auto_detect_env"` // Auto-detect dev/CI
-	PreferFast     bool   `yaml:"prefer_fast" toml:"prefer_fast" json:"prefer_fast"`             // Prefer fast runtimes in dev
-	
+	AutoDetectEnv bool `yaml:"auto_detect_env" toml:"auto_detect_env" json:"auto_detect_env"` // Auto-detect dev/CI
+	PreferFast    bool `yaml:"prefer_fast" toml:"prefer_fast" json:"prefer_fast"`             // Prefer fast runtimes in dev
+
 	// Cache configuration
-	EnableCache    bool     `yaml:"enable_cache" toml:"enable_cache" json:"enable_cache"`
-	CacheDirs      []string `yaml:"cache_dirs" toml:"cache_dirs" json:"cache_dirs"`
-	CacheDir       string   `yaml:"cache_dir" toml:"cache_dir" json:"cache_dir"` // Cache directory for namespace runtime
-	
+	EnableCache bool     `yaml:"enable_cache" toml:"enable_cache" json:"enable_cache"`
+	CacheDirs   []string `yaml:"cache_dirs" toml:"cache_dirs" json:"cache_dirs"`
+	CacheDir    string   `yaml:"cache_dir" toml:"cache_dir" json:"cache_dir"` // Cache directory for namespace runtime
+
 	// Network configuration
-	NetworkMode    string   `yaml:"network_mode" toml:"network_mode" json:"network_mode"` // none, restricted, full
-	AllowNetwork   bool     `yaml:"allow_network" toml:"allow_network" json:"allow_network"` // Allow network access
-	
+	NetworkMode  string `yaml:"network_mode" toml:"network_mode" json:"network_mode"`    // none, restricted, full
+	AllowNetwork bool   `yaml:"allow_network" toml:"allow_network" json:"allow_network"` // Allow network access
+
 	// Filesystem configuration
-	ReadOnlyPaths  []string `yaml:"read_only_paths" toml:"read_only_paths" json:"read_only_paths"`   // Read-only filesystem paths
-	WorkspaceDir   string   `yaml:"workspace_dir" toml:"workspace_dir" json:"workspace_dir"`         // Workspace directory
-	
+	ReadOnlyPaths []string `yaml:"read_only_paths" toml:"read_only_paths" json:"read_only_paths"` // Read-only filesystem paths
+	WorkspaceDir  string   `yaml:"workspace_dir" toml:"workspace_dir" json:"workspace_dir"`       // Workspace directory
+
 	// Security profiles
-	SeccompProfile string   `yaml:"seccomp_profile" toml:"seccomp_profile" json:"seccomp_profile"` // strict, moderate, minimal, none
-	CapabilitySet  string   `yaml:"capability_set" toml:"capability_set" json:"capability_set"`    // none, minimal, normal
-	UseOverlayFS   bool     `yaml:"use_overlayfs" toml:"use_overlayfs" json:"use_overlayfs"`       // Use OverlayFS (namespace only)
-	
+	SeccompProfile string `yaml:"seccomp_profile" toml:"seccomp_profile" json:"seccomp_profile"` // strict, moderate, minimal, none
+	CapabilitySet  string `yaml:"capability_set" toml:"capability_set" json:"capability_set"`    // none, minimal, normal
+	UseOverlayFS   bool   `yaml:"use_overlayfs" toml:"use_overlayfs" json:"use_overlayfs"`       // Use OverlayFS (namespace only)
+
 	// Environment
-	EnvWhitelist   []string `yaml:"env_whitelist" toml:"env_whitelist" json:"env_whitelist"`
-	
+	EnvWhitelist []string `yaml:"env_whitelist" toml:"env_whitelist" json:"env_whitelist"`
+
 	// Custom mounts
-	BindMounts     []BindMountConfig `yaml:"bind_mounts" toml:"bind_mounts" json:"bind_mounts"`
-	
+	BindMounts []BindMountConfig `yaml:"bind_mounts" toml:"bind_mounts" json:"bind_mounts"`
+
 	// Observability
-	EnableMetrics  bool   `yaml:"enable_metrics" toml:"enable_metrics" json:"enable_metrics"`
-	LogOutput      bool   `yaml:"log_output" toml:"log_output" json:"log_output"`
-	ShowRuntimeInfo bool  `yaml:"show_runtime_info" toml:"show_runtime_info" json:"show_runtime_info"` // Show runtime selection
-	
+	EnableMetrics   bool `yaml:"enable_metrics" toml:"enable_metrics" json:"enable_metrics"`
+	LogOutput       bool `yaml:"log_output" toml:"log_output" json:"log_output"`
+	ShowRuntimeInfo bool `yaml:"show_runtime_info" toml:"show_runtime_info" json:"show_runtime_info"` // Show runtime selection
+
 	// Trust store
 	TrustStorePath string `yaml:"trust_store_path" toml:"trust_store_path" json:"trust_store_path"`
 }
@@ -166,28 +166,28 @@ func DefaultConfig() Config {
 	return Config{
 		Logging: LoggingConfig{Format: "text"},
 		Policies: PolicyConfig{
-			Allowlist:          []string{},
-			Denylist:           []string{"rm -rf /", "sudo ", ":(){ :|:& };:", "mkfs", "dd if="},
+			Allowlist: []string{},
+			Denylist:  []string{"rm -rf /", "sudo ", ":(){ :|:& };:", "mkfs", "dd if="},
 			ProtectedDirectories: []string{
-				"/",           // Root directory
-				"/bin",        // System binaries
-				"/sbin",       // System admin binaries
-				"/usr",        // User programs
-				"/usr/bin",    // User binaries
-				"/usr/sbin",   // User admin binaries
-				"/usr/local",  // Local programs
-				"/etc",        // System configuration
-				"/var",        // Variable data
-				"/lib",        // Libraries
-				"/lib64",      // 64-bit libraries
-				"/opt",        // Optional software
-				"/boot",       // Boot files
-				"/root",       // Root home
-				"/sys",        // System files
-				"/proc",       // Process files
-				"/dev",        // Device files
-				"/home",       // User homes
-				"/srv",        // Service data
+				"/",          // Root directory
+				"/bin",       // System binaries
+				"/sbin",      // System admin binaries
+				"/usr",       // User programs
+				"/usr/bin",   // User binaries
+				"/usr/sbin",  // User admin binaries
+				"/usr/local", // Local programs
+				"/etc",       // System configuration
+				"/var",       // Variable data
+				"/lib",       // Libraries
+				"/lib64",     // 64-bit libraries
+				"/opt",       // Optional software
+				"/boot",      // Boot files
+				"/root",      // Root home
+				"/sys",       // System files
+				"/proc",      // Process files
+				"/dev",       // Device files
+				"/home",      // User homes
+				"/srv",       // Service data
 			},
 			MonitorGitOps:      true,
 			BlockForceGit:      true,
@@ -215,46 +215,46 @@ func DefaultConfig() Config {
 			Keywords: []string{"prod", "production", "prd", "live", "staging", "stg"},
 		},
 		Sandbox: SandboxConfig{
-			Enabled:         true,
-			Mode:            SandboxModeAlways, // Always sandbox for maximum security
-			SecurityLevel:   SandboxSecurityBalanced,
-			Runtime:         "auto", // Auto-detect best runtime (bubblewrap > docker > podman)
-			Image:           "ubuntu:22.04",
-			Timeout:         600, // 10 minutes (longer for builds)
-			AutoDetectEnv:   true, // Auto-detect dev/CI
-			PreferFast:      true, // Prefer fast runtimes (bubblewrap/namespace) when available
-			EnableCache:     true, // Enable caching for 10x speedup
+			Enabled:       true,
+			Mode:          SandboxModeAlways, // Always sandbox for maximum security
+			SecurityLevel: SandboxSecurityBalanced,
+			Runtime:       "auto", // Auto-detect best runtime (bubblewrap > docker > podman)
+			Image:         "ubuntu:22.04",
+			Timeout:       600,  // 10 minutes (longer for builds)
+			AutoDetectEnv: true, // Auto-detect dev/CI
+			PreferFast:    true, // Prefer fast runtimes (bubblewrap/namespace) when available
+			EnableCache:   true, // Enable caching for 10x speedup
 			CacheDirs: []string{
 				// Comprehensive cache directories for all major package managers
-				"~/.npm",           // Node.js npm
-				"~/.yarn",          // Yarn
-				"~/.pnpm",          // pnpm
-				"~/.cache/pip",     // Python pip
-				"~/.cache/pip3",    // Python pip3
-				"~/.cargo",         // Rust cargo
-				"~/.rustup",        // Rust toolchain
-				"~/go/pkg",         // Go modules
-				"~/.m2",            // Maven
-				"~/.gradle",        // Gradle
-				"~/.gem",           // Ruby gems
+				"~/.npm",            // Node.js npm
+				"~/.yarn",           // Yarn
+				"~/.pnpm",           // pnpm
+				"~/.cache/pip",      // Python pip
+				"~/.cache/pip3",     // Python pip3
+				"~/.cargo",          // Rust cargo
+				"~/.rustup",         // Rust toolchain
+				"~/go/pkg",          // Go modules
+				"~/.m2",             // Maven
+				"~/.gradle",         // Gradle
+				"~/.gem",            // Ruby gems
 				"~/.cache/go-build", // Go build cache
-				"~/.cache/npm",     // npm cache
-				"~/.cache/yarn",    // Yarn cache
-				"~/.cache/pip",     // pip cache
-				"~/.cache/pip3",    // pip3 cache
-				"~/.cache/cargo",   // Cargo cache
+				"~/.cache/npm",      // npm cache
+				"~/.cache/yarn",     // Yarn cache
+				"~/.cache/pip",      // pip cache
+				"~/.cache/pip3",     // pip3 cache
+				"~/.cache/cargo",    // Cargo cache
 				"~/.cache/composer", // PHP Composer
-				"~/.cache/bower",   // Bower
-				"~/.cache/nuget",  // .NET NuGet
+				"~/.cache/bower",    // Bower
+				"~/.cache/nuget",    // .NET NuGet
 			},
-			CacheDir:        "", // Will use ~/.cache/vectra-guard by default
-			NetworkMode:     "restricted", // Restricted network (allows package managers)
-			AllowNetwork:    true, // Allow network for package installs
-			ReadOnlyPaths:   []string{}, // Will use defaults if empty
-			WorkspaceDir:    "", // Will use current directory by default
-			SeccompProfile:  "moderate", // strict, moderate, minimal, none
-			CapabilitySet:   "minimal",  // none, minimal, normal
-			UseOverlayFS:    true, // Use OverlayFS for /tmp (performance)
+			CacheDir:       "",           // Will use ~/.cache/vectra-guard by default
+			NetworkMode:    "restricted", // Restricted network (allows package managers)
+			AllowNetwork:   true,         // Allow network for package installs
+			ReadOnlyPaths:  []string{},   // Will use defaults if empty
+			WorkspaceDir:   "",           // Will use current directory by default
+			SeccompProfile: "moderate",   // strict, moderate, minimal, none
+			CapabilitySet:  "minimal",    // none, minimal, normal
+			UseOverlayFS:   true,         // Use OverlayFS for /tmp (performance)
 			EnvWhitelist: []string{
 				"HOME", "USER", "PATH", "SHELL", "TERM",
 				"LANG", "LC_ALL", "PWD", "OLDPWD",
@@ -263,7 +263,7 @@ func DefaultConfig() Config {
 				"DOCKER_HOST", "CI", "TRAVIS", "CIRCLE", "JENKINS",
 			},
 			BindMounts:      []BindMountConfig{},
-			EnableMetrics:   true, // Track performance metrics
+			EnableMetrics:   true,  // Track performance metrics
 			LogOutput:       false, // Don't log output by default
 			ShowRuntimeInfo: false, // Don't spam user by default
 			TrustStorePath:  "",
@@ -303,7 +303,7 @@ func resolvePaths(explicit, workdir string) ([]string, error) {
 	} else if homeDir, err := os.UserHomeDir(); err == nil {
 		home = homeDir
 	}
-	
+
 	if home != "" {
 		candidateYAML := filepath.Join(home, ".config", "vectra-guard", "config.yaml")
 		candidateTOML := filepath.Join(home, ".config", "vectra-guard", "config.toml")
@@ -318,11 +318,19 @@ func resolvePaths(explicit, workdir string) ([]string, error) {
 	if workdir != "" {
 		projectYAML := filepath.Join(workdir, "vectra-guard.yaml")
 		projectTOML := filepath.Join(workdir, "vectra-guard.toml")
+		localYAML := filepath.Join(workdir, ".vectra-guard", "config.yaml")
+		localTOML := filepath.Join(workdir, ".vectra-guard", "config.toml")
 		if exists(projectYAML) {
 			paths = append(paths, projectYAML)
 		}
 		if exists(projectTOML) {
 			paths = append(paths, projectTOML)
+		}
+		if exists(localYAML) {
+			paths = append(paths, localYAML)
+		}
+		if exists(localTOML) {
+			paths = append(paths, localTOML)
 		}
 	}
 
@@ -371,17 +379,17 @@ func merge(dst *Config, src Config) {
 	if len(src.Policies.Denylist) > 0 {
 		dst.Policies.Denylist = src.Policies.Denylist
 	}
-	
+
 	// Merge policy booleans (false is a valid value, so we don't check for zero)
 	dst.Policies.MonitorGitOps = src.Policies.MonitorGitOps
 	dst.Policies.BlockForceGit = src.Policies.BlockForceGit
 	dst.Policies.DetectProdEnv = src.Policies.DetectProdEnv
 	dst.Policies.OnlyDestructiveSQL = src.Policies.OnlyDestructiveSQL
-	
+
 	if len(src.Policies.ProdEnvPatterns) > 0 {
 		dst.Policies.ProdEnvPatterns = src.Policies.ProdEnvPatterns
 	}
-	
+
 	// Merge guard level
 	if src.GuardLevel.Level != "" {
 		dst.GuardLevel.Level = src.GuardLevel.Level
@@ -393,7 +401,7 @@ func merge(dst *Config, src Config) {
 		dst.GuardLevel.RequireApprovalAbove = src.GuardLevel.RequireApprovalAbove
 	}
 	dst.GuardLevel.AllowUserBypass = src.GuardLevel.AllowUserBypass
-	
+
 	// Merge production indicators
 	if len(src.ProductionIndicators.Branches) > 0 {
 		dst.ProductionIndicators.Branches = src.ProductionIndicators.Branches
@@ -401,7 +409,7 @@ func merge(dst *Config, src Config) {
 	if len(src.ProductionIndicators.Keywords) > 0 {
 		dst.ProductionIndicators.Keywords = src.ProductionIndicators.Keywords
 	}
-	
+
 	// Merge sandbox configuration
 	if src.Sandbox.Mode != "" {
 		dst.Sandbox.Mode = src.Sandbox.Mode
@@ -543,7 +551,7 @@ func decodeYAML(data []byte) (Config, error) {
 			if commentIdx := strings.Index(value, "#"); commentIdx >= 0 {
 				value = strings.TrimSpace(value[:commentIdx])
 			}
-			
+
 			switch mode {
 			case "logging":
 				if key == "format" {
@@ -685,10 +693,10 @@ func FromContext(ctx context.Context) Config {
 
 // DetectionContext holds information about the execution context
 type DetectionContext struct {
-	Command      string
-	GitBranch    string
-	WorkingDir   string
-	Environment  map[string]string
+	Command     string
+	GitBranch   string
+	WorkingDir  string
+	Environment map[string]string
 }
 
 // DetectGuardLevel analyzes the context and returns the appropriate guard level
@@ -699,14 +707,14 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 	if cfg.GuardLevel.Level != GuardLevelAuto {
 		return cfg.GuardLevel.Level
 	}
-	
+
 	// Auto-detection logic: be safe, choose most protective level when in doubt
 	indicators := cfg.ProductionIndicators
 	if len(indicators.Branches) == 0 && len(indicators.Keywords) == 0 {
 		// Use defaults if not configured
 		indicators = DefaultConfig().ProductionIndicators
 	}
-	
+
 	// Check git branch first (strongest signal for production)
 	if ctx.GitBranch != "" {
 		branchLower := strings.ToLower(ctx.GitBranch)
@@ -722,12 +730,12 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 			}
 		}
 	}
-	
+
 	// Check command string for production indicators
 	if ctx.Command != "" {
 		cmdLower := strings.ToLower(ctx.Command)
 		highRiskKeywords := []string{}
-		
+
 		for _, keyword := range indicators.Keywords {
 			if strings.Contains(cmdLower, strings.ToLower(keyword)) {
 				// Check if in meaningful context
@@ -736,11 +744,11 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 				}
 			}
 		}
-		
+
 		if len(highRiskKeywords) > 0 {
 			return GuardLevelHigh // Production in command = high
 		}
-		
+
 		// Check for deployment-related commands
 		deploymentKeywords := []string{"deploy", "release", "publish", "ship"}
 		for _, keyword := range deploymentKeywords {
@@ -749,7 +757,7 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 			}
 		}
 	}
-	
+
 	// Check working directory for indicators
 	if ctx.WorkingDir != "" {
 		dirLower := strings.ToLower(ctx.WorkingDir)
@@ -759,12 +767,12 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 			}
 		}
 	}
-	
+
 	// Check environment variables
 	for key, value := range ctx.Environment {
 		keyLower := strings.ToLower(key)
 		valueLower := strings.ToLower(value)
-		
+
 		// Check for environment indicators in variable names or values
 		envIndicators := []string{"env", "environment", "stage", "tier"}
 		isEnvVar := false
@@ -774,7 +782,7 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 				break
 			}
 		}
-		
+
 		if isEnvVar {
 			for _, keyword := range indicators.Keywords {
 				if strings.Contains(valueLower, strings.ToLower(keyword)) {
@@ -783,7 +791,7 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 			}
 		}
 	}
-	
+
 	// Default: medium (safe default, not too restrictive, not too permissive)
 	return GuardLevelMedium
 }
@@ -793,7 +801,7 @@ func DetectGuardLevel(cfg Config, ctx DetectionContext) GuardLevel {
 func isInMeaningfulContext(text, keyword string) bool {
 	lower := strings.ToLower(text)
 	keyLower := strings.ToLower(keyword)
-	
+
 	// Check if keyword appears with typical delimiters (either side)
 	contexts := []string{
 		"/" + keyLower + "/",
@@ -818,27 +826,27 @@ func isInMeaningfulContext(text, keyword string) bool {
 		" " + keyLower + "/",
 		":" + keyLower,
 	}
-	
+
 	for _, ctx := range contexts {
 		if strings.Contains(lower, ctx) {
 			return true
 		}
 	}
-	
+
 	// Also check if at start or end with delimiter
-	if strings.HasPrefix(lower, keyLower+" ") || 
-	   strings.HasPrefix(lower, keyLower+"-") ||
-	   strings.HasPrefix(lower, keyLower+"_") ||
-	   strings.HasPrefix(lower, keyLower+".") ||
-	   strings.HasPrefix(lower, keyLower+"/") ||
-	   strings.HasSuffix(lower, " "+keyLower) ||
-	   strings.HasSuffix(lower, "-"+keyLower) ||
-	   strings.HasSuffix(lower, "_"+keyLower) ||
-	   strings.HasSuffix(lower, "."+keyLower) ||
-	   strings.HasSuffix(lower, "/"+keyLower) {
+	if strings.HasPrefix(lower, keyLower+" ") ||
+		strings.HasPrefix(lower, keyLower+"-") ||
+		strings.HasPrefix(lower, keyLower+"_") ||
+		strings.HasPrefix(lower, keyLower+".") ||
+		strings.HasPrefix(lower, keyLower+"/") ||
+		strings.HasSuffix(lower, " "+keyLower) ||
+		strings.HasSuffix(lower, "-"+keyLower) ||
+		strings.HasSuffix(lower, "_"+keyLower) ||
+		strings.HasSuffix(lower, "."+keyLower) ||
+		strings.HasSuffix(lower, "/"+keyLower) {
 		return true
 	}
-	
+
 	return false
 }
 
@@ -850,12 +858,12 @@ func GetCurrentGitBranch(workdir string) string {
 	if err != nil {
 		return ""
 	}
-	
+
 	content := strings.TrimSpace(string(data))
 	// Format: ref: refs/heads/branch-name
 	if strings.HasPrefix(content, "ref: refs/heads/") {
 		return strings.TrimPrefix(content, "ref: refs/heads/")
 	}
-	
+
 	return ""
 }

--- a/internal/roadmap/roadmap.go
+++ b/internal/roadmap/roadmap.go
@@ -1,0 +1,193 @@
+package roadmap
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/vectra-guard/vectra-guard/internal/logging"
+)
+
+type Roadmap struct {
+	Workspace string    `json:"workspace"`
+	Items     []Item    `json:"items"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type Item struct {
+	ID        string     `json:"id"`
+	Title     string     `json:"title"`
+	Summary   string     `json:"summary"`
+	Status    string     `json:"status"`
+	Tags      []string   `json:"tags"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	Logs      []LogEntry `json:"logs"`
+}
+
+type LogEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Note      string    `json:"note"`
+	SessionID string    `json:"session_id,omitempty"`
+	Source    string    `json:"source"`
+}
+
+type Manager struct {
+	path      string
+	workspace string
+	logger    *logging.Logger
+}
+
+func NewManager(workspace string, logger *logging.Logger) (*Manager, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+	abs, err := filepath.Abs(workspace)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace: %w", err)
+	}
+	baseDir, err := roadmapDir()
+	if err != nil {
+		return nil, err
+	}
+	name := fmt.Sprintf("%s.json", hashWorkspace(abs))
+	return &Manager{
+		path:      filepath.Join(baseDir, name),
+		workspace: abs,
+		logger:    logger,
+	}, nil
+}
+
+func (m *Manager) Load() (*Roadmap, error) {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Roadmap{Workspace: m.workspace, Items: []Item{}, UpdatedAt: time.Now()}, nil
+		}
+		return nil, fmt.Errorf("read roadmap: %w", err)
+	}
+
+	var rm Roadmap
+	if err := json.Unmarshal(data, &rm); err != nil {
+		return nil, fmt.Errorf("parse roadmap: %w", err)
+	}
+	if rm.Workspace == "" {
+		rm.Workspace = m.workspace
+	}
+	return &rm, nil
+}
+
+func (m *Manager) Save(roadmap *Roadmap) error {
+	roadmap.UpdatedAt = time.Now()
+	data, err := json.MarshalIndent(roadmap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal roadmap: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+		return fmt.Errorf("create roadmap directory: %w", err)
+	}
+	if err := os.WriteFile(m.path, data, 0o644); err != nil {
+		return fmt.Errorf("write roadmap: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) AddItem(roadmap *Roadmap, item Item) error {
+	item.ID = newID()
+	item.CreatedAt = time.Now()
+	item.UpdatedAt = item.CreatedAt
+	roadmap.Items = append(roadmap.Items, item)
+	if err := m.Save(roadmap); err != nil {
+		return err
+	}
+	m.logger.Info("roadmap item added", map[string]any{
+		"item_id": item.ID,
+		"title":   item.Title,
+		"status":  item.Status,
+	})
+	return nil
+}
+
+func (m *Manager) UpdateStatus(roadmap *Roadmap, itemID, status string) error {
+	item := findItem(roadmap, itemID)
+	if item == nil {
+		return fmt.Errorf("item not found: %s", itemID)
+	}
+	item.Status = status
+	item.UpdatedAt = time.Now()
+	if err := m.Save(roadmap); err != nil {
+		return err
+	}
+	m.logger.Info("roadmap status updated", map[string]any{
+		"item_id": item.ID,
+		"status":  status,
+	})
+	return nil
+}
+
+func (m *Manager) AddLog(roadmap *Roadmap, itemID string, entry LogEntry) error {
+	item := findItem(roadmap, itemID)
+	if item == nil {
+		return fmt.Errorf("item not found: %s", itemID)
+	}
+	entry.Timestamp = time.Now()
+	item.Logs = append(item.Logs, entry)
+	item.UpdatedAt = time.Now()
+	if err := m.Save(roadmap); err != nil {
+		return err
+	}
+	m.logger.Info("roadmap log added", map[string]any{
+		"item_id":  item.ID,
+		"has_note": entry.Note != "",
+		"session":  entry.SessionID,
+	})
+	return nil
+}
+
+func (m *Manager) ListItems(roadmap *Roadmap) []Item {
+	items := append([]Item(nil), roadmap.Items...)
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+	return items
+}
+
+func (m *Manager) GetItem(roadmap *Roadmap, itemID string) *Item {
+	item := findItem(roadmap, itemID)
+	if item == nil {
+		return nil
+	}
+	copy := *item
+	return &copy
+}
+
+func findItem(roadmap *Roadmap, itemID string) *Item {
+	for i := range roadmap.Items {
+		if roadmap.Items[i].ID == itemID {
+			return &roadmap.Items[i]
+		}
+	}
+	return nil
+}
+
+func roadmapDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".vectra-guard", "roadmaps"), nil
+}
+
+func hashWorkspace(path string) string {
+	sum := sha256.Sum256([]byte(path))
+	return hex.EncodeToString(sum[:])
+}
+
+func newID() string {
+	return fmt.Sprintf("rm-%d", time.Now().UnixNano())
+}

--- a/internal/summarizer/advanced.go
+++ b/internal/summarizer/advanced.go
@@ -1,0 +1,237 @@
+package summarizer
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type advancedFuncSummary struct {
+	name      string
+	signature string
+	doc       string
+	calls     []string
+	startLine int
+	endLine   int
+}
+
+type funcGraphStats struct {
+	inDegree  int
+	outDegree int
+	callers   []string
+}
+
+type advancedCacheEntry struct {
+	scored []scoredLine
+}
+
+var advancedCache sync.Map
+
+// SummarizeCodeAdvanced builds a function-level summary using Go AST heuristics.
+func SummarizeCodeAdvanced(text string, maxItems int) []string {
+	if maxItems <= 0 {
+		return nil
+	}
+	cacheKey := hashContent(text)
+	if cached, ok := advancedCache.Load(cacheKey); ok {
+		entry := cached.(advancedCacheEntry)
+		return selectTop(entry.scored, maxItems)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "input.go", text, parser.ParseComments)
+	if err != nil {
+		return SummarizeCode(text, maxItems)
+	}
+
+	summaries := buildAdvancedSummaries(fset, file)
+	if len(summaries) == 0 {
+		return SummarizeCode(text, maxItems)
+	}
+
+	graphStats := buildGraphStats(summaries)
+	scored := make([]scoredLine, 0, len(summaries))
+	for i, summary := range summaries {
+		stats := graphStats[summary.name]
+		score := scoreFuncSummary(summary, stats)
+		scored = append(scored, scoredLine{index: i, text: formatFuncSummary(summary, stats), score: score})
+	}
+
+	advancedCache.Store(cacheKey, advancedCacheEntry{scored: scored})
+	return selectTop(scored, maxItems)
+}
+
+func buildAdvancedSummaries(fset *token.FileSet, file *ast.File) []advancedFuncSummary {
+	var summaries []advancedFuncSummary
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		summary := advancedFuncSummary{
+			name:      fn.Name.Name,
+			signature: formatFuncSignature(fset, fn),
+			doc:       strings.TrimSpace(extractDoc(fn)),
+			calls:     collectCalls(fn),
+			startLine: fset.Position(fn.Pos()).Line,
+			endLine:   fset.Position(fn.End()).Line,
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries
+}
+
+func formatFuncSignature(fset *token.FileSet, fn *ast.FuncDecl) string {
+	buf := &bytes.Buffer{}
+	if fn.Recv != nil {
+		_ = printer.Fprint(buf, fset, fn.Recv)
+		buf.WriteString(" ")
+	}
+	buf.WriteString(fn.Name.Name)
+	_ = printer.Fprint(buf, fset, fn.Type.Params)
+	if fn.Type.Results != nil {
+		buf.WriteString(" ")
+		_ = printer.Fprint(buf, fset, fn.Type.Results)
+	}
+	return buf.String()
+}
+
+func extractDoc(fn *ast.FuncDecl) string {
+	if fn.Doc == nil {
+		return ""
+	}
+	var lines []string
+	for _, comment := range fn.Doc.List {
+		text := strings.TrimSpace(strings.TrimPrefix(comment.Text, "//"))
+		text = strings.TrimSpace(strings.TrimPrefix(text, "/*"))
+		text = strings.TrimSpace(strings.TrimSuffix(text, "*/"))
+		if text == "" {
+			continue
+		}
+		lines = append(lines, text)
+	}
+	return strings.Join(lines, " ")
+}
+
+func collectCalls(fn *ast.FuncDecl) []string {
+	calls := map[string]struct{}{}
+	if fn.Body == nil {
+		return nil
+	}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			calls[fun.Name] = struct{}{}
+		case *ast.SelectorExpr:
+			calls[fun.Sel.Name] = struct{}{}
+		}
+		return true
+	})
+
+	if len(calls) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(calls))
+	for name := range calls {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func scoreFuncSummary(summary advancedFuncSummary, stats funcGraphStats) float64 {
+	score := 2.0
+	if summary.doc != "" {
+		score += 1.2
+	}
+	lines := summary.endLine - summary.startLine
+	if lines > 0 {
+		score += float64(min(lines/10, 3))
+	}
+	score += float64(min(stats.outDegree, 4)) * 0.25
+	score += float64(min(stats.inDegree, 4)) * 0.35
+	return score
+}
+
+func formatFuncSummary(summary advancedFuncSummary, stats funcGraphStats) string {
+	parts := []string{fmt.Sprintf("func %s", summary.signature)}
+	if summary.doc != "" {
+		parts = append(parts, fmt.Sprintf("doc: %s", summary.doc))
+	}
+	if len(summary.calls) > 0 {
+		parts = append(parts, fmt.Sprintf("calls: %s", strings.Join(summary.calls, ", ")))
+	}
+	if stats.inDegree > 0 {
+		parts = append(parts, fmt.Sprintf("callers: %d", stats.inDegree))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func buildGraphStats(summaries []advancedFuncSummary) map[string]funcGraphStats {
+	defined := make(map[string]struct{}, len(summaries))
+	for _, summary := range summaries {
+		defined[summary.name] = struct{}{}
+	}
+
+	stats := make(map[string]funcGraphStats, len(summaries))
+	for _, summary := range summaries {
+		stats[summary.name] = funcGraphStats{}
+	}
+
+	for _, summary := range summaries {
+		outSet := make(map[string]struct{})
+		for _, call := range summary.calls {
+			if _, ok := defined[call]; !ok {
+				continue
+			}
+			outSet[call] = struct{}{}
+		}
+
+		if len(outSet) == 0 {
+			continue
+		}
+
+		entry := stats[summary.name]
+		entry.outDegree = len(outSet)
+		stats[summary.name] = entry
+
+		for callee := range outSet {
+			target := stats[callee]
+			target.inDegree++
+			target.callers = append(target.callers, summary.name)
+			stats[callee] = target
+		}
+	}
+
+	for name, entry := range stats {
+		if len(entry.callers) > 1 {
+			sort.Strings(entry.callers)
+		}
+		stats[name] = entry
+	}
+
+	return stats
+}
+
+func hashContent(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -1,0 +1,167 @@
+package summarizer
+
+import (
+	"sort"
+	"strings"
+)
+
+type scoredLine struct {
+	index int
+	text  string
+	score float64
+}
+
+var stopWords = map[string]struct{}{
+	"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {}, "be": {}, "but": {}, "by": {},
+	"for": {}, "from": {}, "has": {}, "have": {}, "if": {}, "in": {}, "into": {}, "is": {},
+	"it": {}, "its": {}, "of": {}, "on": {}, "or": {}, "such": {}, "that": {}, "the": {},
+	"their": {}, "then": {}, "there": {}, "these": {}, "they": {}, "this": {}, "to": {},
+	"was": {}, "will": {}, "with": {}, "you": {}, "your": {},
+}
+
+// SummarizeText extracts the most relevant sentences using a lightweight frequency heuristic.
+func SummarizeText(text string, maxSentences int) []string {
+	if maxSentences <= 0 {
+		return nil
+	}
+	sentences := splitSentences(text)
+	if len(sentences) == 0 {
+		return nil
+	}
+
+	wordFreq := make(map[string]int)
+	for _, sentence := range sentences {
+		for _, token := range tokenize(sentence) {
+			wordFreq[token]++
+		}
+	}
+
+	scored := make([]scoredLine, 0, len(sentences))
+	for i, sentence := range sentences {
+		score := 0.0
+		for _, token := range tokenize(sentence) {
+			score += float64(wordFreq[token])
+		}
+		scored = append(scored, scoredLine{index: i, text: sentence, score: score})
+	}
+
+	return selectTop(scored, maxSentences)
+}
+
+// SummarizeCode extracts high-signal lines from code using simple structural heuristics.
+func SummarizeCode(text string, maxLines int) []string {
+	if maxLines <= 0 {
+		return nil
+	}
+	lines := strings.Split(text, "\n")
+	scored := make([]scoredLine, 0, len(lines))
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		score := scoreCodeLine(trimmed)
+		scored = append(scored, scoredLine{index: i, text: trimmed, score: score})
+	}
+
+	return selectTop(scored, maxLines)
+}
+
+func scoreCodeLine(line string) float64 {
+	switch {
+	case strings.HasPrefix(line, "func "):
+		return 3.0
+	case strings.HasPrefix(line, "type "):
+		return 2.6
+	case strings.HasPrefix(line, "//"):
+		return 2.2
+	case strings.HasPrefix(line, "/*"):
+		return 2.0
+	case strings.HasPrefix(line, "const "):
+		return 1.8
+	case strings.HasPrefix(line, "var "):
+		return 1.6
+	case strings.HasPrefix(line, "package "):
+		return 1.2
+	case strings.HasPrefix(line, "import "):
+		return 1.1
+	default:
+		return 0.5
+	}
+}
+
+func selectTop(scored []scoredLine, maxItems int) []string {
+	if len(scored) == 0 {
+		return nil
+	}
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].score == scored[j].score {
+			return scored[i].index < scored[j].index
+		}
+		return scored[i].score > scored[j].score
+	})
+
+	if maxItems > len(scored) {
+		maxItems = len(scored)
+	}
+
+	selected := scored[:maxItems]
+	sort.SliceStable(selected, func(i, j int) bool {
+		return selected[i].index < selected[j].index
+	})
+
+	result := make([]string, 0, len(selected))
+	for _, item := range selected {
+		result = append(result, item.text)
+	}
+	return result
+}
+
+func splitSentences(text string) []string {
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	var sentences []string
+	var current strings.Builder
+	runes := []rune(text)
+	for i, r := range runes {
+		current.WriteRune(r)
+		if r == '.' || r == '!' || r == '?' {
+			isEnd := i == len(runes)-1
+			nextIsSpace := !isEnd && (runes[i+1] == ' ' || runes[i+1] == '\t')
+			if isEnd || nextIsSpace {
+				sentence := strings.TrimSpace(current.String())
+				if sentence != "" {
+					sentences = append(sentences, sentence)
+				}
+				current.Reset()
+			}
+		}
+	}
+	if tail := strings.TrimSpace(current.String()); tail != "" {
+		sentences = append(sentences, tail)
+	}
+	return sentences
+}
+
+func tokenize(text string) []string {
+	fields := strings.Fields(strings.ToLower(text))
+	if len(fields) == 0 {
+		return nil
+	}
+	tokens := make([]string, 0, len(fields))
+	for _, field := range fields {
+		token := strings.Trim(field, "\"'()[]{}<>.,;:!?*`~")
+		if token == "" {
+			continue
+		}
+		if _, found := stopWords[token]; found {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+	return tokens
+}


### PR DESCRIPTION
### Motivation
- Improve agentic development by surfacing quick repo context summaries and an advanced Go summarizer so agents and humans can navigate code faster.
- Provide a repo-local initialization and cache option to keep workspace settings/scoped cache out of global config and avoid committing large artifacts.
- Add a lightweight roadmap feature to let teams record plans, logs, and status tied to a workspace for agent + human coordination.
- Make new features discoverable via an on-tool `help` command and integrate CLI plumbing for `context`, `roadmap`, and `init`.

### Description
- Added CLI commands and wiring in `cmd/root.go` for `help`, `context summarize`, `roadmap` subcommands, and `init --local`, plus new command handlers under `cmd/` (`help.go`, `context.go`, `roadmap.go`, `flags.go`) and updates to `cmd/init.go` to write repo-local config and create `.vectra-guard/cache/`.
- Implemented summarization utilities in `internal/summarizer/` including `SummarizeText`, `SummarizeCode`, and an AST-based `SummarizeCodeAdvanced` in `advanced.go` for Go function/call-graph signals with caching.
- Implemented roadmap storage and manager in `internal/roadmap/roadmap.go` to persist per-workspace JSON roadmaps and expose add/list/show/status/log operations used by the CLI.
- Updated configuration loading and defaults in `internal/config/config.go` to discover project-local files at `.vectra-guard/config.{yaml,toml}`, merge sandbox fields so local settings (e.g., `CacheDir`, `WorkspaceDir`) are honored, and updated docs and `.gitignore` (`README.md`, `GETTING_STARTED.md`, `.gitignore`) to document features and ignore repo-local cache.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69648aeb84e48322bbb93c9cf88ec735)