### PR TITLE
Wire Docker runtime to sandbox executor, enforce timeouts and surface errors

### DIFF
--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -306,7 +306,10 @@ func TestBuildSandboxConfig(t *testing.T) {
 				ShouldCache: false,
 			}
 
-			sandboxCfg := executor.buildSandboxConfig(decision)
+			sandboxCfg, err := executor.buildSandboxConfig(decision)
+			if err != nil {
+				t.Fatalf("buildSandboxConfig() error = %v", err)
+			}
 			tt.checkFunc(t, sandboxCfg)
 		})
 	}


### PR DESCRIPTION
### Motivation

- Prevent hard failures when the runtime selector picks Docker by wiring the Docker runtime executor to the existing sandbox execution path (`executeDocker`).
- Enforce configured sandbox timeouts so long-running or hung commands can be terminated (`context.WithTimeout`).
- Surface filesystem errors so failures are diagnosable by returning errors on cache directory creation (`os.MkdirAll`) and working directory resolution (`os.Getwd`).

### Description

- Implemented `dockerRuntimeExecutor.Execute` in `internal/sandbox/runtime.go` to build the sandbox config via `buildSandboxConfig`, apply `context.WithTimeout` when `Timeout` is set, and call `Executor.executeDocker`.
- Changed `buildSandboxConfig` in `internal/sandbox/sandbox.go` to return `(SandboxConfig, error)` and now propagate `os.Getwd` errors instead of ignoring them.
- Applied sandbox timeout handling in `executeInSandbox` by creating a deadline from `SandboxConfig.Timeout` and updated callers to handle the new error return from `buildSandboxConfig`.
- Checked and return errors from cache directory creation (`os.MkdirAll`) in the runtime selector and updated `internal/sandbox/sandbox_test.go` to handle the new `buildSandboxConfig` error return.

### Testing

- Ran `gofmt -w` on the modified files and committed the changes to ensure formatting consistency.
- No automated unit or integration tests were executed in this rollout.
- Updated unit tests in `internal/sandbox/sandbox_test.go` to handle the new error-returning `buildSandboxConfig`, but they were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f41d81ec83228429b314c58bc443)